### PR TITLE
Prevent Spigot from compiling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
 
     // Spigot API
-    implementation group: 'org.spigotmc', name: 'spigot-api', version: '1.8.8-R0.1-SNAPSHOT'
+    compileOnly group: 'org.spigotmc', name: 'spigot-api', version: '1.8.8-R0.1-SNAPSHOT'
 }
 
 task testJar(type: Jar) {


### PR DESCRIPTION
Spigot previously compiled which caused issues with the Maven artifact.