### PR TITLE
Refactored inventory interaction event blocking system

### DIFF
--- a/src/main/java/com/samjakob/spigui/SpiGUI.java
+++ b/src/main/java/com/samjakob/spigui/SpiGUI.java
@@ -6,8 +6,6 @@ import com.samjakob.spigui.menu.SGOpenMenu;
 import com.samjakob.spigui.toolbar.SGDefaultToolbarBuilder;
 import com.samjakob.spigui.toolbar.SGToolbarBuilder;
 import org.bukkit.entity.Player;
-import org.bukkit.event.inventory.ClickType;
-import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -109,7 +107,7 @@ public class SpiGUI {
     }
 
     /**
-     * An alias for {@link #create(String, int, String, ClickType...)} with the tag set to null.
+     * An alias for {@link #create(String, int, String)} with the tag set to null.
      * Use this method if you don't need the tag, or you don't know what it's for.
      * <br>
      * The rows parameter is used in place of the size parameter of the
@@ -171,24 +169,8 @@ public class SpiGUI {
      * @param tag The inventory's tag.
      * @return The created inventory.
      */
-    public SGMenu create(String name, int rows, String tag, ClickType... permittedMenuClickTypes) {
-        return new SGMenu(plugin, this, name, rows, tag, permittedMenuClickTypes);
-    }
-
-    /**
-     * Creates an inventory with the given name, rows, tag, permittedMenuClickTypes, blockedMenuActions,
-     * and blockedAdjacentActions.
-     *
-     * @param name The display name of the inventory.
-     * @param rows The number of rows the inventory should have per page.
-     * @param tag The inventory's tag.
-     * @param permittedMenuClickTypes The permitted menu click types.
-     * @param blockedMenuActions The blocked menu actions.
-     * @param blockedAdjacentActions The blocked adjacent actions.
-     * @return The created inventory.
-     */
-    public SGMenu create(String name, int rows, String tag, ClickType[] permittedMenuClickTypes, InventoryAction[] blockedMenuActions, InventoryAction[] blockedAdjacentActions) {
-        return new SGMenu(plugin, this, name, rows, tag, permittedMenuClickTypes, blockedMenuActions, blockedAdjacentActions);
+    public SGMenu create(String name, int rows, String tag) {
+        return new SGMenu(plugin, this, name, rows, tag);
     }
 
     /**

--- a/src/main/java/com/samjakob/spigui/SpiGUI.java
+++ b/src/main/java/com/samjakob/spigui/SpiGUI.java
@@ -1,14 +1,13 @@
 package com.samjakob.spigui;
 
-import com.samjakob.spigui.buttons.SGButton;
 import com.samjakob.spigui.menu.SGMenu;
 import com.samjakob.spigui.menu.SGMenuListener;
 import com.samjakob.spigui.menu.SGOpenMenu;
-import com.samjakob.spigui.item.ItemBuilder;
 import com.samjakob.spigui.toolbar.SGDefaultToolbarBuilder;
 import com.samjakob.spigui.toolbar.SGToolbarBuilder;
-import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -110,7 +109,7 @@ public class SpiGUI {
     }
 
     /**
-     * An alias for {@link #create(String, int, String)} with the tag set to null.
+     * An alias for {@link #create(String, int, String, ClickType...)} with the tag set to null.
      * Use this method if you don't need the tag, or you don't know what it's for.
      * <br>
      * The rows parameter is used in place of the size parameter of the
@@ -172,8 +171,24 @@ public class SpiGUI {
      * @param tag The inventory's tag.
      * @return The created inventory.
      */
-    public SGMenu create(String name, int rows, String tag) {
-        return new SGMenu(plugin, this, name, rows, tag);
+    public SGMenu create(String name, int rows, String tag, ClickType... permittedMenuClickTypes) {
+        return new SGMenu(plugin, this, name, rows, tag, permittedMenuClickTypes);
+    }
+
+    /**
+     * Creates an inventory with the given name, rows, tag, permittedMenuClickTypes, blockedMenuActions,
+     * and blockedAdjacentActions.
+     *
+     * @param name The display name of the inventory.
+     * @param rows The number of rows the inventory should have per page.
+     * @param tag The inventory's tag.
+     * @param permittedMenuClickTypes The permitted menu click types.
+     * @param blockedMenuActions The blocked menu actions.
+     * @param blockedAdjacentActions The blocked adjacent actions.
+     * @return The created inventory.
+     */
+    public SGMenu create(String name, int rows, String tag, ClickType[] permittedMenuClickTypes, InventoryAction[] blockedMenuActions, InventoryAction[] blockedAdjacentActions) {
+        return new SGMenu(plugin, this, name, rows, tag, permittedMenuClickTypes, blockedMenuActions, blockedAdjacentActions);
     }
 
     /**

--- a/src/main/java/com/samjakob/spigui/menu/SGMenu.java
+++ b/src/main/java/com/samjakob/spigui/menu/SGMenu.java
@@ -77,19 +77,19 @@ public class SGMenu implements InventoryHolder {
      * this menu without further processing (i.e., the button's
      * listener will not be called).
      */
-    private ClickType[] permittedMenuClickTypes;
+    private HashSet<ClickType> permittedMenuClickTypes;
 
     /**
      * Any actions in this list will be blocked immediately without further
      * processing if they occur in a SpiGUI menu.
      */
-    private InventoryAction[] blockedMenuActions;
+    private HashSet<InventoryAction> blockedMenuActions;
 
     /**
      * Any actions in this list will be blocked if they occur in the adjacent
      * inventory to an SGMenu.
      */
-    private InventoryAction[] blockedAdjacentActions;
+    private HashSet<InventoryAction> blockedAdjacentActions;
 
     /// DEFAULT PERMITTED / BLOCKED ACTIONS ///
 
@@ -637,27 +637,27 @@ public class SGMenu implements InventoryHolder {
     /**
      * Returns the permitted menu click types.
      *
-     * @return an array of permitted menu click types
+     * @return A hashSet of permitted menu click types
      */
-    public ClickType[] getPermittedMenuClickTypes() {
+    public HashSet<ClickType> getPermittedMenuClickTypes() {
         return this.permittedMenuClickTypes;
     }
 
     /**
      * Returns an array of blocked menu actions for the current Inventory.
      *
-     * @return an array of blocked menu actions
+     * @return A hashSet of blocked menu actions
      */
-    public InventoryAction[] getBlockedMenuActions() {
+    public HashSet<InventoryAction> getBlockedMenuActions() {
         return this.blockedMenuActions;
     }
 
     /**
      * Returns the blocked adjacent actions for this object.
      *
-     * @return An array of InventoryAction objects representing the blocked adjacent actions.
+     * @return A hashSet of InventoryAction objects representing the blocked adjacent actions.
      */
-    public InventoryAction[] getBlockedAdjacentActions() {
+    public HashSet<InventoryAction> getBlockedAdjacentActions() {
         return this.blockedAdjacentActions;
     }
 
@@ -667,7 +667,7 @@ public class SGMenu implements InventoryHolder {
      * @param clickTypes One or more click types you want to allow for this menu.
      */
     public void setPermittedMenuClickTypes(ClickType... clickTypes) {
-        this.permittedMenuClickTypes = clickTypes;
+        this.permittedMenuClickTypes = new HashSet<>(Arrays.asList(clickTypes));
     }
 
     /**
@@ -676,7 +676,7 @@ public class SGMenu implements InventoryHolder {
      * @param actions the menu actions to be blocked
      */
     public void setBlockedMenuActions(InventoryAction... actions) {
-        this.blockedMenuActions = actions;
+        this.blockedMenuActions = new HashSet<>(Arrays.asList(actions));
     }
 
     /**
@@ -685,7 +685,62 @@ public class SGMenu implements InventoryHolder {
      * @param actions The actions to be blocked.
      */
     public void setBlockedAdjacentActions(InventoryAction... actions) {
-        this.blockedAdjacentActions = actions;
+        this.blockedAdjacentActions = new HashSet<>(Arrays.asList(actions));
+    }
+
+    /**
+     * Adds a permitted click type to the menu.
+     *
+     * @param clickType the click type to be added
+     */
+    public void addPermittedClickType(ClickType clickType) {
+        this.permittedMenuClickTypes.add(clickType);
+    }
+
+    /**
+     * Adds the given InventoryAction to the list of blocked menu actions.
+     * Blocked menu actions are actions that are not allowed to be performed on the inventory menu.
+     *
+     * @param action The InventoryAction to be added to the blocked menu actions list.
+     */
+    public void addBlockedMenuAction(InventoryAction action) {
+        this.blockedMenuActions.add(action);
+    }
+
+    /**
+     * Adds a blocked adjacent action to the list of blocked adjacent actions.
+     *
+     * @param action The inventory action to be added as blocked adjacent action.
+     */
+    public void addBlockedAdjacentAction(InventoryAction action) {
+        this.getBlockedAdjacentActions().add(action);
+    }
+
+    /**
+     * Removes a permitted click type from the list of permitted menu click types.
+     *
+     * @param clickType the click type to be removed
+     */
+    public void removePermittedClickType(ClickType clickType) {
+        this.permittedMenuClickTypes.remove(clickType);
+    }
+
+    /**
+     * Removes the specified InventoryAction from the list of blocked menu actions.
+     *
+     * @param action the InventoryAction to be removed
+     */
+    public void removeBlockedMenuAction(InventoryAction action) {
+        this.blockedMenuActions.remove(action);
+    }
+
+    /**
+     * Removes the given action from the list of blocked adjacent actions.
+     *
+     * @param action The action to be removed
+     */
+    public void removeBlockedAdjacentAction(InventoryAction action) {
+        this.getBlockedAdjacentActions().remove(action);
     }
 
     /// INVENTORY API ///

--- a/src/main/java/com/samjakob/spigui/menu/SGMenu.java
+++ b/src/main/java/com/samjakob/spigui/menu/SGMenu.java
@@ -124,7 +124,7 @@ public class SGMenu implements InventoryHolder {
      * @param permittedMenuClickTypes the permitted menu click types
      */
     public SGMenu(JavaPlugin owner, SpiGUI spiGUI, String name, int rowsPerPage, String tag, ClickType... permittedMenuClickTypes) {
-        this(owner, spiGUI, name, rowsPerPage, tag, permittedMenuClickTypes.length == 0 ? permittedMenuClickTypes : DEFAULT_PERMITTED_MENU_CLICK_TYPES, DEFAULT_BLOCKED_MENU_ACTIONS, DEFAULT_BLOCKED_ADJACENT_ACTIONS);
+        this(owner, spiGUI, name, rowsPerPage, tag, permittedMenuClickTypes.length > 0 ? permittedMenuClickTypes : DEFAULT_PERMITTED_MENU_CLICK_TYPES, DEFAULT_BLOCKED_MENU_ACTIONS, DEFAULT_BLOCKED_ADJACENT_ACTIONS);
     }
 
     /**

--- a/src/main/java/com/samjakob/spigui/menu/SGMenu.java
+++ b/src/main/java/com/samjakob/spigui/menu/SGMenu.java
@@ -124,7 +124,7 @@ public class SGMenu implements InventoryHolder {
      * @param permittedMenuClickTypes the permitted menu click types
      */
     public SGMenu(JavaPlugin owner, SpiGUI spiGUI, String name, int rowsPerPage, String tag, ClickType... permittedMenuClickTypes) {
-        this(owner, spiGUI, name, rowsPerPage, tag, permittedMenuClickTypes != null ? permittedMenuClickTypes : DEFAULT_PERMITTED_MENU_CLICK_TYPES, DEFAULT_BLOCKED_MENU_ACTIONS, DEFAULT_BLOCKED_ADJACENT_ACTIONS);
+        this(owner, spiGUI, name, rowsPerPage, tag, permittedMenuClickTypes.length == 0 ? permittedMenuClickTypes : DEFAULT_PERMITTED_MENU_CLICK_TYPES, DEFAULT_BLOCKED_MENU_ACTIONS, DEFAULT_BLOCKED_ADJACENT_ACTIONS);
     }
 
     /**

--- a/src/main/java/com/samjakob/spigui/menu/SGMenu.java
+++ b/src/main/java/com/samjakob/spigui/menu/SGMenu.java
@@ -25,7 +25,7 @@ import java.util.function.Consumer;
  * <br><br>
  * You do not instantiate this class when you need it - as you would
  * have done with the older version of the library - rather you make a
- * call to {@link SpiGUI#create(String, int)}, {@link SpiGUI#create(String, int, String, ClickType...)} or {@link SpiGUI#create(String, int, String, ClickType[], InventoryAction[], InventoryAction[])}
+ * call to {@link SpiGUI#create(String, int)} or {@link SpiGUI#create(String, int, String)}
  * from your plugin's {@link SpiGUI} instance.
  * <br><br>
  * This creates an inventory that is already associated with your plugin.
@@ -77,19 +77,19 @@ public class SGMenu implements InventoryHolder {
      * this menu without further processing (i.e., the button's
      * listener will not be called).
      */
-    public final ArrayList<ClickType> permittedMenuClickTypes;
+    private ClickType[] permittedMenuClickTypes;
 
     /**
      * Any actions in this list will be blocked immediately without further
      * processing if they occur in a SpiGUI menu.
      */
-    public final ArrayList<InventoryAction> blockedMenuActions;
+    private InventoryAction[] blockedMenuActions;
 
     /**
      * Any actions in this list will be blocked if they occur in the adjacent
      * inventory to an SGMenu.
      */
-    public final ArrayList<InventoryAction> blockedAdjacentActions;
+    private InventoryAction[] blockedAdjacentActions;
 
     /// DEFAULT PERMITTED / BLOCKED ACTIONS ///
 
@@ -109,26 +109,7 @@ public class SGMenu implements InventoryHolder {
     };
 
     /**
-     * <b>Intended for internal use only. Use {@link SpiGUI#create(String, int)}, {@link SpiGUI#create(String, int, String, ClickType...)} or {@link SpiGUI#create(String, int, String, ClickType[], InventoryAction[], InventoryAction[])}!</b><br>
-     * Used by the library internally to construct an SGMenu.
-     * <br>
-     * The name parameter is color code translated.
-     * <br>
-     * Will use default permitted click types and blocked menu actions
-     *
-     * @param owner                   the JavaPlugin that owns this menu
-     * @param spiGUI                  the SpiGUI instance
-     * @param name                    the name of the menu
-     * @param rowsPerPage             the number of rows per page in the menu
-     * @param tag                     the tag associated with the menu
-     * @param permittedMenuClickTypes the permitted menu click types
-     */
-    public SGMenu(JavaPlugin owner, SpiGUI spiGUI, String name, int rowsPerPage, String tag, ClickType... permittedMenuClickTypes) {
-        this(owner, spiGUI, name, rowsPerPage, tag, permittedMenuClickTypes.length > 0 ? permittedMenuClickTypes : DEFAULT_PERMITTED_MENU_CLICK_TYPES, DEFAULT_BLOCKED_MENU_ACTIONS, DEFAULT_BLOCKED_ADJACENT_ACTIONS);
-    }
-
-    /**
-     * <b>Intended for internal use only. Use {@link SpiGUI#create(String, int)}, {@link SpiGUI#create(String, int, String, ClickType...)} or {@link SpiGUI#create(String, int, String, ClickType[], InventoryAction[], InventoryAction[])}!</b><br>
+     * <b>Intended for internal use only. Use {@link SpiGUI#create(String, int)} or {@link SpiGUI#create(String, int, String)}!</b><br>
      * Used by the library internally to construct an SGMenu.
      * <br>
      * The name parameter is color code translated.
@@ -138,11 +119,8 @@ public class SGMenu implements InventoryHolder {
      * @param name                       The name of the menu.
      * @param rowsPerPage                The number of rows per page in the menu.
      * @param tag                        The tag associated with this menu.
-     * @param permittedMenuClickTypes    An array of permitted ClickTypes for this menu.
-     * @param blockedMenuActions         An array of blocked InventoryActions for this menu.
-     * @param blockedAdjacentActions     An array of blocked InventoryActions for adjacent menus.
      */
-    public SGMenu(JavaPlugin owner, SpiGUI spiGUI, String name, int rowsPerPage, String tag, ClickType[] permittedMenuClickTypes, InventoryAction[] blockedMenuActions, InventoryAction[] blockedAdjacentActions) {
+    public SGMenu(JavaPlugin owner, SpiGUI spiGUI, String name, int rowsPerPage, String tag) {
         this.owner = owner;
         this.spiGUI = spiGUI;
         this.name = ChatColor.translateAlternateColorCodes('&', name);
@@ -153,10 +131,6 @@ public class SGMenu implements InventoryHolder {
         this.stickiedSlots = new HashSet<>();
 
         this.currentPage = 0;
-
-        this.permittedMenuClickTypes = new ArrayList<>(Arrays.asList(permittedMenuClickTypes));
-        this.blockedMenuActions = new ArrayList<>(Arrays.asList(blockedMenuActions));
-        this.blockedAdjacentActions = new ArrayList<>(Arrays.asList(blockedAdjacentActions));
     }
 
     /// INVENTORY SETTINGS ///
@@ -658,6 +632,60 @@ public class SGMenu implements InventoryHolder {
      */
     public void setOnPageChange(Consumer<SGMenu> onPageChange) {
         this.onPageChange = onPageChange;
+    }
+
+    /**
+     * Returns the permitted menu click types.
+     *
+     * @return an array of permitted menu click types
+     */
+    public ClickType[] getPermittedMenuClickTypes() {
+        return this.permittedMenuClickTypes;
+    }
+
+    /**
+     * Returns an array of blocked menu actions for the current Inventory.
+     *
+     * @return an array of blocked menu actions
+     */
+    public InventoryAction[] getBlockedMenuActions() {
+        return this.blockedMenuActions;
+    }
+
+    /**
+     * Returns the blocked adjacent actions for this object.
+     *
+     * @return An array of InventoryAction objects representing the blocked adjacent actions.
+     */
+    public InventoryAction[] getBlockedAdjacentActions() {
+        return this.blockedAdjacentActions;
+    }
+
+    /**
+     * Sets the permitted menu click types.
+     *
+     * @param clickTypes One or more click types you want to allow for this menu.
+     */
+    public void setPermittedMenuClickTypes(ClickType... clickTypes) {
+        this.permittedMenuClickTypes = clickTypes;
+    }
+
+    /**
+     * Sets the blocked menu actions for the inventory.
+     *
+     * @param actions the menu actions to be blocked
+     */
+    public void setBlockedMenuActions(InventoryAction... actions) {
+        this.blockedMenuActions = actions;
+    }
+
+    /**
+     * Sets the blocked adjacent actions for this object.
+     *
+     * @param actions The actions to be blocked.
+     */
+    public void setBlockedAdjacentActions(InventoryAction... actions) {
+        this.blockedAdjacentActions = actions;
     }
 
     /// INVENTORY API ///

--- a/src/main/java/com/samjakob/spigui/menu/SGMenuListener.java
+++ b/src/main/java/com/samjakob/spigui/menu/SGMenuListener.java
@@ -120,11 +120,9 @@ public class SGMenuListener implements Listener {
             return;
         }
 
-        // If the action is blocked, instantly deny the event and do nothing
-        // else.
+        // If the action is blocked, instantly deny the event
         if (clickedGui.blockedMenuActions.stream().anyMatch(action -> action == event.getAction())) {
             event.setResult(Event.Result.DENY);
-            return;
         }
 
         // Check if the GUI is owner by the current plugin

--- a/src/main/java/com/samjakob/spigui/menu/SGMenuListener.java
+++ b/src/main/java/com/samjakob/spigui/menu/SGMenuListener.java
@@ -13,6 +13,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.Set;
 
@@ -115,13 +116,13 @@ public class SGMenuListener implements Listener {
 
         // If the click type is not permitted, instantly deny the event and
         // do nothing else.
-        if (clickedGui.permittedMenuClickTypes.stream().noneMatch(type -> type == event.getClick())) {
+        if (Arrays.stream(clickedGui.getPermittedMenuClickTypes()).noneMatch(type -> type == event.getClick())) {
             event.setResult(Event.Result.DENY);
             return;
         }
 
         // If the action is blocked, instantly deny the event
-        if (clickedGui.blockedMenuActions.stream().anyMatch(action -> action == event.getAction())) {
+        if (Arrays.stream(clickedGui.getBlockedMenuActions()).anyMatch(action -> action == event.getAction())) {
             event.setResult(Event.Result.DENY);
         }
 
@@ -197,7 +198,7 @@ public class SGMenuListener implements Listener {
 
         // If the clicked inventory is not a SpiGUI menu, block the event if
         // it is one of the blocked actions.
-        if (clickedGui.blockedAdjacentActions.stream().anyMatch(action -> action == event.getAction())) {
+        if (Arrays.stream(clickedGui.getBlockedAdjacentActions()).anyMatch(action -> action == event.getAction())) {
             event.setResult(Event.Result.DENY);
         }
     }

--- a/src/main/java/com/samjakob/spigui/menu/SGMenuListener.java
+++ b/src/main/java/com/samjakob/spigui/menu/SGMenuListener.java
@@ -13,7 +13,6 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.util.Arrays;
 import java.util.Objects;
 import java.util.Set;
 
@@ -116,13 +115,13 @@ public class SGMenuListener implements Listener {
 
         // If the click type is not permitted, instantly deny the event and
         // do nothing else.
-        if (Arrays.stream(clickedGui.getPermittedMenuClickTypes()).noneMatch(type -> type == event.getClick())) {
+        if (clickedGui.getPermittedMenuClickTypes().stream().noneMatch(type -> type == event.getClick())) {
             event.setResult(Event.Result.DENY);
             return;
         }
 
         // If the action is blocked, instantly deny the event
-        if (Arrays.stream(clickedGui.getBlockedMenuActions()).anyMatch(action -> action == event.getAction())) {
+        if (clickedGui.getBlockedMenuActions().stream().anyMatch(action -> action == event.getAction())) {
             event.setResult(Event.Result.DENY);
         }
 
@@ -198,7 +197,7 @@ public class SGMenuListener implements Listener {
 
         // If the clicked inventory is not a SpiGUI menu, block the event if
         // it is one of the blocked actions.
-        if (Arrays.stream(clickedGui.getBlockedAdjacentActions()).anyMatch(action -> action == event.getAction())) {
+        if (clickedGui.getBlockedAdjacentActions().stream().anyMatch(action -> action == event.getAction())) {
             event.setResult(Event.Result.DENY);
         }
     }


### PR DESCRIPTION
I ran into an issue while using SpiGUI as a dependency for my project where I couldn't use SHIFT + CLICK at all.
It turned out to be a hardcoded block, this update is to resolve this issue!

I've moved these blocks to the SGMenu, so the user can set the blockers / permitters themselves for every individual menu.
Although the user doesn't have to enter any settings, SGMenu and SpiGUI.create still has the old constructor that will automatically use the traditional blockers & permitters.

I've tried to copy you guy's code style as much as possible, please let me know if there is anything that needs changing before merging. I'm open for feedback! :)