### PR TITLE
1.21.1 Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,8 @@ version '1.4.0'
 uri "https://github.com/SamJakob/SpiGUI"
 
 java {
-    sourceCompatibility = 1.8
-    targetCompatibility = 1.8
+    sourceCompatibility = 21
+    targetCompatibility = 21
 
     withJavadocJar()
     withSourcesJar()
@@ -32,8 +32,8 @@ repositories {
 
 dependencies {
     // Spigot API
-    compileOnly group: 'org.spigotmc', name: 'spigot-api', version: '1.8.8-R0.1-SNAPSHOT'
-    testCompileOnly group: 'org.spigotmc', name: 'spigot-api', version: '1.8.8-R0.1-SNAPSHOT'
+    compileOnly group: 'org.spigotmc', name: 'spigot-api', version: '1.21.1-R0.1-SNAPSHOT'
+    testCompileOnly group: 'org.spigotmc', name: 'spigot-api', version: '1.21.1-R0.1-SNAPSHOT'
 }
 
 // Builds Spigot runnable plugin from the test package.

--- a/src/main/java/com/samjakob/spigui/menu/SGMenu.java
+++ b/src/main/java/com/samjakob/spigui/menu/SGMenu.java
@@ -83,13 +83,13 @@ public class SGMenu implements InventoryHolder {
      * Any actions in this list will be blocked immediately without further
      * processing if they occur in a SpiGUI menu.
      */
-    private HashSet<InventoryAction> blockedMenuActions;
+    private HashSet<InventoryAction> blockedMenuActions = new HashSet<>(Arrays.asList(DEFAULT_BLOCKED_MENU_ACTIONS));
 
     /**
      * Any actions in this list will be blocked if they occur in the adjacent
      * inventory to an SGMenu.
      */
-    private HashSet<InventoryAction> blockedAdjacentActions;
+    private HashSet<InventoryAction> blockedAdjacentActions = new HashSet<>(Arrays.asList(DEFAULT_BLOCKED_ADJACENT_ACTIONS));
 
     /// DEFAULT PERMITTED / BLOCKED ACTIONS ///
 
@@ -130,7 +130,7 @@ public class SGMenu implements InventoryHolder {
      * @param rowsPerPage                The number of rows per page in the menu.
      * @param tag                        The tag associated with this menu.
      */
-    public SGMenu(JavaPlugin owner, SpiGUI spiGUI, String name, int rowsPerPage, String tag) {
+    public SGMenu(JavaPlugin owner, SpiGUI spiGUI, String name, int rowsPerPage, String tag, ClickType... clickTypes) {
         this.owner = owner;
         this.spiGUI = spiGUI;
         this.name = ChatColor.translateAlternateColorCodes('&', name);
@@ -141,6 +141,8 @@ public class SGMenu implements InventoryHolder {
         this.stickiedSlots = new HashSet<>();
 
         this.currentPage = 0;
+
+        this.permittedMenuClickTypes = clickTypes.length > 0 ? new HashSet<>(Arrays.asList(clickTypes)) : new HashSet<>(Arrays.asList(DEFAULT_PERMITTED_MENU_CLICK_TYPES));
     }
 
     /// INVENTORY SETTINGS ///

--- a/src/main/java/com/samjakob/spigui/menu/SGMenuListener.java
+++ b/src/main/java/com/samjakob/spigui/menu/SGMenuListener.java
@@ -185,7 +185,7 @@ public class SGMenuListener implements Listener {
     public void onAdjacentInventoryClick(InventoryClickEvent event) {
         // If the clicked inventory is not adjacent to a SpiGUI menu, ignore
         // the click event.
-        if (event.getView().getTopInventory() == null ||
+        if (event.getView().getTopInventory().isEmpty() ||
                 shouldIgnoreInventoryEvent(event.getView().getTopInventory())) return;
 
         // If the clicked inventory is the SpiGUI menu (the top inventory),
@@ -193,7 +193,10 @@ public class SGMenuListener implements Listener {
         if (event.getClickedInventory() == event.getView().getTopInventory()) return;
 
         // Get the instance of the SpiGUI that was clicked.
-        SGMenu clickedGui = (SGMenu) event.getClickedInventory().getHolder();
+        SGMenu clickedGui = (SGMenu) event.getView().getTopInventory().getHolder();
+
+        if(clickedGui == null)
+            return;
 
         // If the clicked inventory is not a SpiGUI menu, block the event if
         // it is one of the blocked actions.


### PR DESCRIPTION
Hey I'm back!

I recently upgraded my server to 1.21.1 and SpiGUI was throwing an error when trying to cast the `.getHandle()` of the inventory to a `SGMenu`. I have updated the spigot version to 1.21.1 and fixed the error by changing `(SGMenu) event.getClickedInventory().getHolder();` to `(SGMenu) event.getView().getTopInventory().getHolder();`.
I don't know if updating to 1.20.6+ is desired for this library, if not, discard this PR!

I also added clickTypes to the constructor, this was very convenient for me, but I'm open to feedback of course!